### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "get_if_addrs"
 readme = "README.md"
 repository = "https://github.com/maidsafe/get_if_addrs"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 clippy = {version = "~0.0.175", optional = true}


### PR DESCRIPTION
This is extremely required since I got [nullptr deref](https://github.com/maidsafe/get_if_addrs/pull/33) on 0.5.0!!!