### PR TITLE
Make link name on Windows all lowercase

### DIFF
--- a/src/ifaddrs_windows.rs
+++ b/src/ifaddrs_windows.rs
@@ -81,7 +81,7 @@ impl IpAdapterAddresses {
     }
 }
 
-#[link(name = "Iphlpapi")]
+#[link(name = "iphlpapi")]
 extern "system" {
     /// Get adapter's addresses.
     fn GetAdaptersAddresses(


### PR DESCRIPTION
Fixes https://github.com/maidsafe/get_if_addrs/issues/52