### PR TITLE
Upgrade to rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-    - RUST_STABLE=1.29.1
 os:
   - linux
   - osx
 language: rust
 rust:
-  - 1.29.1
+  - stable
 sudo: false
 branches:
   only:
@@ -20,12 +19,13 @@ cache:
 before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune
-  - rustup component add rustfmt-preview
-  - rustup component add clippy-preview
+  - rustup component add rustfmt
+  - rustup component add clippy
 script:
   - set -x;
-    cargo test --release --verbose &&
     cargo fmt -- --check &&
-    cargo clippy && cargo clippy --profile=test
+    cargo clippy &&
+    cargo clippy --profile=test &&
+    cargo test --release --verbose
 before_cache:
   - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "get_if_addrs"
 readme = "README.md"
 repository = "https://github.com/maidsafe/get_if_addrs"
 version = "0.5.3"
+edition = "2018"
 
 [dependencies]
 clippy = {version = "~0.0.175", optional = true}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     RUST_BACKTRACE: 1
   matrix:
-    - RUST_TOOLCHAIN: 1.29.1
+    - RUST_TOOLCHAIN: stable
 
 branches:
   only:

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -26,8 +26,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -56,7 +56,7 @@
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(feature = "clippy", deny(clippy, clippy_pedantic))]
 
-extern crate get_if_addrs;
+use get_if_addrs;
 
 fn main() {
     let ifaces = get_if_addrs::get_if_addrs().unwrap();

--- a/src/ifaddrs_posix.rs
+++ b/src/ifaddrs_posix.rs
@@ -7,11 +7,11 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+use crate::sockaddr;
 #[cfg(target_os = "android")]
 use get_if_addrs_sys::{freeifaddrs, getifaddrs, ifaddrs};
 #[cfg(not(target_os = "android"))]
 use libc::{freeifaddrs, getifaddrs, ifaddrs};
-use sockaddr;
 use std::net::IpAddr;
 use std::{io, mem};
 

--- a/src/ifaddrs_posix.rs
+++ b/src/ifaddrs_posix.rs
@@ -15,25 +15,17 @@ use sockaddr;
 use std::net::IpAddr;
 use std::{io, mem};
 
-#[cfg(
-    any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "nacl"
-    )
-)]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "nacl"))]
 pub fn do_broadcast(ifaddr: &ifaddrs) -> Option<IpAddr> {
     sockaddr::to_ipaddr(ifaddr.ifa_ifu)
 }
 
-#[cfg(
-    any(
-        target_os = "freebsd",
-        target_os = "ios",
-        target_os = "macos",
-        target_os = "openbsd"
-    )
-)]
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "ios",
+    target_os = "macos",
+    target_os = "openbsd"
+))]
 pub fn do_broadcast(ifaddr: &ifaddrs) -> Option<IpAddr> {
     sockaddr::to_ipaddr(ifaddr.ifa_dstaddr)
 }
@@ -43,7 +35,7 @@ pub struct IfAddrs {
 }
 
 impl IfAddrs {
-    #[allow(unsafe_code)]
+    #[allow(unsafe_code, clippy::new_ret_no_self)]
     pub fn new() -> io::Result<Self> {
         let mut ifaddrs: *mut ifaddrs;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,6 @@ maidsafe_logo.png",
 )]
 #![allow(clippy::use_debug, clippy::too_many_arguments)]
 
-#[cfg(windows)]
-extern crate winapi;
-
 #[cfg(not(windows))]
 mod ifaddrs_posix;
 #[cfg(windows)]
@@ -82,7 +79,6 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 extern crate unwrap;
 #[cfg(target_os = "android")]
 extern crate get_if_addrs_sys;
-extern crate libc;
 
 /// Details about an interface on this host.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -171,8 +167,8 @@ impl Ifv6Addr {
 #[cfg(not(windows))]
 mod getifaddrs_posix {
     use super::{IfAddr, Ifv4Addr, Ifv6Addr, Interface};
-    use ifaddrs_posix::{self as ifaddrs, IfAddrs};
-    use sockaddr;
+    use crate::ifaddrs_posix::{self as ifaddrs, IfAddrs};
+    use crate::sockaddr;
     use std::ffi::CStr;
     use std::io;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -247,8 +243,8 @@ pub fn get_if_addrs() -> io::Result<Vec<Interface>> {
 #[cfg(windows)]
 mod getifaddrs_windows {
     use super::{IfAddr, Ifv4Addr, Ifv6Addr, Interface};
-    use ifaddrs_windows::IfAddrs;
-    use sockaddr;
+    use crate::ifaddrs_windows::IfAddrs;
+    use crate::sockaddr;
     use std::io;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,6 @@ maidsafe_logo.png",
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,
@@ -60,19 +58,13 @@ maidsafe_logo.png",
     missing_debug_implementations,
     variant_size_differences
 )]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    deny(
-        clippy,
-        unicode_not_nfc,
-        wrong_pub_self_convention,
-        option_unwrap_used
-    )
+#![deny(
+    clippy::all,
+    clippy::unicode_not_nfc,
+    clippy::wrong_pub_self_convention,
+    clippy::option_unwrap_used
 )]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(use_debug, too_many_arguments)
-)]
+#![allow(clippy::use_debug, clippy::too_many_arguments)]
 
 #[cfg(windows)]
 extern crate winapi;
@@ -288,7 +280,8 @@ mod getifaddrs_windows {
                                         let y_byte = a.octets()[n];
                                         // Clippy 0.0.128 doesn't handle the label on the `continue`
                                         #[cfg_attr(
-                                            feature = "cargo-clippy", allow(needless_continue)
+                                            feature = "cargo-clippy",
+                                            allow(needless_continue)
                                         )]
                                         for m in 0..8 {
                                             if (n * 8) + m > prefix.prefix_length as usize {
@@ -345,7 +338,8 @@ mod getifaddrs_windows {
                                         let y_word = a.segments()[n];
                                         // Clippy 0.0.128 doesn't handle the label on the `continue`
                                         #[cfg_attr(
-                                            feature = "cargo-clippy", allow(needless_continue)
+                                            feature = "cargo-clippy",
+                                            allow(needless_continue)
                                         )]
                                         for m in 0..16 {
                                             if (n * 16) + m > prefix.prefix_length as usize {
@@ -442,16 +436,11 @@ mod tests {
                     }
                 }
                 None
-            }).collect()
+            })
+            .collect()
     }
 
-    #[cfg(
-        any(
-            target_os = "linux",
-            target_os = "android",
-            target_os = "nacl"
-        )
-    )]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "nacl"))]
     fn list_system_addrs() -> Vec<IpAddr> {
         list_system_interfaces("ip", "addr")
             .lines()
@@ -463,16 +452,11 @@ mod tests {
                     return Some(IpAddr::V4(unwrap!(Ipv4Addr::from_str(addr[0]))));
                 }
                 None
-            }).collect()
+            })
+            .collect()
     }
 
-    #[cfg(
-        any(
-            target_os = "freebsd",
-            target_os = "macos",
-            target_os = "ios"
-        )
-    )]
+    #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
     fn list_system_addrs() -> Vec<IpAddr> {
         list_system_interfaces("ifconfig", "")
             .lines()
@@ -483,7 +467,8 @@ mod tests {
                     return Some(IpAddr::V4(unwrap!(Ipv4Addr::from_str(addr_s[1]))));
                 }
                 None
-            }).collect()
+            })
+            .collect()
     }
 
     #[test]

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -27,6 +27,7 @@ struct SockAddr {
 }
 
 impl SockAddr {
+    #[allow(clippy::new_ret_no_self)]
     fn new(sockaddr: *const sockaddr) -> Option<Self> {
         NonNull::new(sockaddr as *mut _).map(|inner| Self { inner })
     }
@@ -94,13 +95,13 @@ impl SockAddr {
     }
 
     #[allow(unsafe_code)]
-    #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
+    #[allow(clippy::cast_ptr_alignment)]
     fn sa_in(&self) -> sockaddr_in {
         unsafe { *(self.inner.as_ptr() as *const sockaddr_in) }
     }
 
     #[allow(unsafe_code)]
-    #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
+    #[allow(clippy::cast_ptr_alignment)]
     fn sa_in6(&self) -> sockaddr_in6 {
         unsafe { *(self.inner.as_ptr() as *const sockaddr_in6) }
     }


### PR DESCRIPTION
* Upgrade compiler
* Switch to 2018 edition
* Fix compilation, fmt and clippy warnings
* Remove nightly from CI
