### PR TITLE
Add NetBSD support

### DIFF
--- a/src/ifaddrs_posix.rs
+++ b/src/ifaddrs_posix.rs
@@ -24,7 +24,8 @@ pub fn do_broadcast(ifaddr: &ifaddrs) -> Option<IpAddr> {
     target_os = "freebsd",
     target_os = "ios",
     target_os = "macos",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "netbsd"
 ))]
 pub fn do_broadcast(ifaddr: &ifaddrs) -> Option<IpAddr> {
     sockaddr::to_ipaddr(ifaddr.ifa_dstaddr)


### PR DESCRIPTION
It _should_ be the same as OpenBSD, but haven't been able to run the tests yet due to version of cargo I'm on (1.29.0).

It does however build fine and work as part of a parent crate.